### PR TITLE
Rework contact submission

### DIFF
--- a/services/app/app/controllers/review/contact.js
+++ b/services/app/app/controllers/review/contact.js
@@ -103,20 +103,20 @@ export default Controller.extend(ActionMixin, {
 
         const addedIds = await Promise.all(contacts
           .filter((obj) => obj.payload.enabled && obj.payload.added)
-          .map(async ({ updated }) => this.createContact(updated))
+          .map(({ updated }) => this.createContact(updated))
         );
 
         const removedIds = await Promise.all(contacts
           .filter((obj) => obj.payload.enabled && obj.payload.removed)
-          .map(async ({ original }) => this.deleteContact(original.id))
+          .map(({ original }) => this.deleteContact(original.id))
         );
 
         await Promise.all(contacts
           .filter((obj) => obj.payload.enabled && (!obj.payload.added && !obj.payload.removed))
-          .map(async (obj) => {
+          .map((obj) => {
             const fields = Object.keys(obj.payload.fields).filter(k => obj.payload.fields[k] === true);
             const update = fields.reduce((o, f) => ({ ...o, [f]: obj.updated[f] }), { id: obj.original.id });
-            return await this.updateContact(update);
+            return this.updateContact(update);
           })
         );
 

--- a/services/app/app/controllers/review/contact.js
+++ b/services/app/app/controllers/review/contact.js
@@ -33,6 +33,7 @@ export default Controller.extend(ActionMixin, {
    * @param Number contactId The contact ID
    */
   async uploadContactImage (primaryImage, contactId) {
+    // Only upload a new image if we have a value (it was changed in the payload)
     if (!primaryImage) return false;
     const { src } = primaryImage;
     const uploadVars = { input: { url: src } };
@@ -44,12 +45,11 @@ export default Controller.extend(ActionMixin, {
   },
 
   /**
-   * Creates contact, uploads/assigns primary image, and adds to company.
+   * Creates contact, uploads/assigns primary image
    *
-   * @param Number contentId The company ID
    * @param Object { ... } The contact payload
    */
-  async createContact (contentId, contactIds, { firstName, lastName, title, primaryImage }) {
+  async createContact ({ firstName, lastName, title, primaryImage }) {
     const getDefaultSection = async () => {
       const { edges } = await this.apollo.query({ query: contactSection }, 'websiteSections');
       return get(edges, '0.node.id');
@@ -59,30 +59,22 @@ export default Controller.extend(ActionMixin, {
     const variables = { input: { payload } };
     const { id: contactId } = await this.apollo.mutate({ mutation: contactCreate, variables }, 'createContentContact');
     await this.uploadContactImage(primaryImage, contactId);
-
-    const ids = [contactId, ...contactIds];
-    const updateVars = { input: { id: contentId, payload: { contactIds: ids } } };
-    return this.apollo.mutate({ mutation: companyContacts, variables: updateVars });
+    return contactId;
   },
 
   /**
-   * Sets status:0 on contact and removes from company.
+   * Sets status:0 on contact
    *
-   * @param Number contentId The company ID
-   * @param Object { id } The contact to remove
+   * @param Number id The contact to delete
    */
-  async deleteContact (contentId, contactIds, { id }) {
+  async deleteContact (id) {
     const variables = { input: { id, payload: { status: 0 } } };
-    await this.apollo.mutate({ mutation: contactUpdate, variables });
-    const ids = contactIds.filter(v => v !== id);
-    const updateVars = { input: { id: contentId, payload: { contactIds: ids } } };
-    return this.apollo.mutate({ mutation: companyContacts, variables: updateVars });
+    return this.apollo.mutate({ mutation: contactUpdate, variables });
   },
 
   /**
-   * Creates contact, uploads/assigns primary image, and adds to company.
+   * Creates contact, uploads/assigns primary image
    *
-   * @param Number contentId The company ID
    * @param Object { ... } The contact payload
    */
   async updateContact ({ id, firstName, lastName, title, primaryImage }) {
@@ -108,15 +100,34 @@ export default Controller.extend(ActionMixin, {
         const contentId = this.get('model.company.id');
         const contactIds = this.get('model.company.publicContacts.edges').map(({ node }) => node.id);
 
-        await Promise.all(contacts.reduce((arr, obj) => {
+        // Perform contact operations and build related contact ids
+        const relatedContactIds = await contacts.reduce(async (chain, obj) => {
           const { original, updated, payload } = obj;
-          if (!payload.enabled) return arr;
-          if (payload.added) return [...arr, this.createContact(contentId, contactIds, updated)];
-          if (payload.removed) return [...arr, this.deleteContact(contentId, contactIds, original)];
+          if (!payload.enabled) return chain;
+          const resolved = await chain;
+
+          // Contact was added
+          if (payload.added) {
+            const contactId = await this.createContact(updated);
+            return [...resolved, contactId];
+          }
+          // Contact was removed
+          if (payload.removed) {
+            const contactId = original.id;
+            await this.deleteContact(contactId);
+            return resolved.filter(v => v != contactId)
+          }
+          // Contact was modified
           const fields = Object.keys(obj.payload.fields).filter(k => obj.payload.fields[k] === true);
           const update = fields.reduce((o, f) => ({ ...o, [f]: obj.updated[f] }), { id: obj.original.id });
-          return [...arr, this.updateContact(update)];
-        }, []));
+
+          await this.updateContact(update);
+          return resolved;
+        }, contactIds);
+
+        // Update the company with the contact ids
+        const updateVars = { input: { id: contentId, payload: { contactIds: relatedContactIds } } };
+        await this.apollo.mutate({ mutation: companyContacts, variables: updateVars });
 
         set(this, 'model.submission.reviewed', true);
         await this.apollo.mutate({ mutation: discard, variables: { id }, refetchQueries: ['ContentUpdateListSubmissions'] });


### PR DESCRIPTION
[Trello #4: Contacts missing company relationship](https://trello.com/c/P1I6SUT3/4-contacts-missing-company-relationship)

Resolve race condition when setting company contacts. Previously the update to the `company.publicContacts` reference was done within the `Promise.all`, resulting in multiple calls to adjust the related contact ids, without updating the state of those ids.

Now, perform a single update operation after creating/removing/updating contacts to adjust the related contact ids.