### PR TITLE
Set primarySection to home of related company on create of contacts/promotions

### DIFF
--- a/services/app/app/controllers/review/contact.js
+++ b/services/app/app/controllers/review/contact.js
@@ -49,9 +49,10 @@ export default Controller.extend(ActionMixin, {
    *
    * @param Object { ... } The contact payload
    */
-  async createContact ({ firstName, lastName, title, primaryImage }) {
+  async createContact ({ firstName, lastName, title, primaryImage }, primarySiteId) {
     const getDefaultSection = async () => {
-      const { edges } = await this.apollo.query({ query: contactSection }, 'websiteSections');
+      const variables = { siteId: primarySiteId };
+      const { edges } = await this.apollo.query({ query: contactSection, variables, fetchPolicy: 'network-only' }, 'websiteSections');
       return get(edges, '0.node.id');
     };
     const primarySectionId = await getDefaultSection();
@@ -100,10 +101,11 @@ export default Controller.extend(ActionMixin, {
         const contacts = this.get('model.contacts');
         const contentId = this.get('model.company.id');
         const contactIds = this.get('model.company.publicContacts.edges').map(({ node }) => node.id);
+        const primarySiteId = this.get('model.company.primarySite.id');
 
         const addedIds = await Promise.all(contacts
           .filter((obj) => obj.payload.enabled && obj.payload.added)
-          .map(({ updated }) => this.createContact(updated))
+          .map(({ updated }) => this.createContact(updated, primarySiteId))
         );
 
         const removedIds = await Promise.all(contacts

--- a/services/app/app/gql/fragments/company/list.graphql
+++ b/services/app/app/gql/fragments/company/list.graphql
@@ -3,4 +3,7 @@ fragment CompanyListFragment on ContentCompany {
   name
   hash
   labels
+  primarySite {
+    id
+  }
 }

--- a/services/app/app/gql/queries/review/contact-section.graphql
+++ b/services/app/app/gql/queries/review/contact-section.graphql
@@ -1,5 +1,5 @@
-query CompanyUpdateDefaultWebsiteSection {
-  websiteSections(input: { includeAliases: "home", rootOnly: true, pagination: { limit: 1 } }){
+query CompanyUpdateDefaultWebsiteSection($siteId: ObjectID!) {
+  websiteSections(input: { siteId: $siteId, includeAliases: "home", rootOnly: true, pagination: { limit: 1 } }){
     edges {
       node {
         id


### PR DESCRIPTION
 - Add primarySite.id to company fragment
 - pass related company.primarySite.id when querying for home section to set on new contact/promotion as primarySection

This will ensure that the primary section of new contacts/promotions are set to the same site's home section. 