### PR TITLE
Limit displayed sections to primary site

### DIFF
--- a/services/app/app/gql/fragments/leadership/section.js
+++ b/services/app/app/gql/fragments/leadership/section.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag';
+
+export default gql`
+fragment LeadershipSectionFragment on WebsiteSection {
+  id
+  name
+  alias
+}
+`;

--- a/services/app/app/gql/queries/config.graphql
+++ b/services/app/app/gql/queries/config.graphql
@@ -14,6 +14,7 @@ query CompanyUpdateConfig {
     leadershipCompanyLabel
     leadershipSectionAlias
     leadershipSectionMax
+    leadershipPrimarySiteOnly
     locale
   }
 }

--- a/services/app/app/gql/queries/portal/categories.js
+++ b/services/app/app/gql/queries/portal/categories.js
@@ -1,6 +1,12 @@
 import gql from 'graphql-tag';
+import LeadershipSectionFragment from '../../fragments/leadership/section';
+
 export default gql`
-query ContentUpdateLeadershipData($sites: WebsiteSitesQueryInput!, $leaders: WebsiteSiteSectionsInput!, $children: WebsiteSectionChildrenInput!) {
+query ContentUpdateLeadershipData(
+  $sites: WebsiteSitesQueryInput!,
+  $leaders: WebsiteSiteSectionsInput!,
+  $children: WebsiteSectionChildrenInput!
+) {
   websiteSites(input: $sites) {
     edges {
       node {
@@ -9,22 +15,16 @@ query ContentUpdateLeadershipData($sites: WebsiteSitesQueryInput!, $leaders: Web
         sections(input: $leaders) {
           edges {
             node {
-              id
-              name
-              alias
+              ...LeadershipSectionFragment,
               children(input: $children) {
                 edges {
                   node {
-                    id
-                    name
-                    alias
+                    ...LeadershipSectionFragment,
                     children(input: $children) {
                       totalCount
                       edges {
                         node {
-                          id
-                          name
-                          alias
+                          ...LeadershipSectionFragment,
                         }
                       }
                     }
@@ -38,4 +38,5 @@ query ContentUpdateLeadershipData($sites: WebsiteSitesQueryInput!, $leaders: Web
     }
   }
 }
+${LeadershipSectionFragment}
 `;

--- a/services/app/app/gql/queries/portal/leadership-single.js
+++ b/services/app/app/gql/queries/portal/leadership-single.js
@@ -1,0 +1,54 @@
+import gql from 'graphql-tag';
+import LeadershipSectionFragment from '../../fragments/leadership/section';
+
+export default gql`
+query ContentUpdateLeadershipData(
+  $site: WebsiteSiteQueryInput!,
+  $leaders: WebsiteSectionsQueryInput!,
+  $children: WebsiteSectionChildrenInput!
+) {
+  websiteSite(input: $site) {
+    id
+    name
+  }
+  websiteSections(input: $leaders) {
+    totalCount
+    edges {
+      node {
+        # Primary
+        ...LeadershipSectionFragment
+        children(input: $children) {
+          totalCount
+          edges {
+            node {
+              # Secondary
+              ...LeadershipSectionFragment
+              children(input: $children) {
+                totalCount
+                edges {
+                  node {
+                    # Tertiary
+                    ...LeadershipSectionFragment
+                    children(input: $children) {
+                      totalCount
+                      edges {
+                        node {
+                          # Quaternary
+                          id
+                          name
+                          alias
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+${LeadershipSectionFragment}
+`;

--- a/services/app/app/routes/application.js
+++ b/services/app/app/routes/application.js
@@ -22,6 +22,7 @@ export default Route.extend(ApplicationRouteMixin, {
     leadershipCompanyLabel,
     leadershipSectionAlias,
     leadershipSectionMax,
+    leadershipPrimarySiteOnly,
     locale
   }) {
     this.config.load({
@@ -34,6 +35,7 @@ export default Route.extend(ApplicationRouteMixin, {
       leadershipCompanyLabel,
       leadershipSectionAlias,
       leadershipSectionMax,
+      leadershipPrimarySiteOnly,
       locale
     });
   },

--- a/services/app/app/routes/portal/leadership.js
+++ b/services/app/app/routes/portal/leadership.js
@@ -1,14 +1,41 @@
 import Route from '@ember/routing/route';
 import { inject } from '@ember/service';
 import { queryManager } from 'ember-apollo-client';
-import query from '@base-cms/company-update-app/gql/queries/portal/categories';
+import { get } from '@ember/object';
+import multi from '@base-cms/company-update-app/gql/queries/portal/categories';
+import single from '@base-cms/company-update-app/gql/queries/portal/leadership-single';
 
 export default Route.extend({
   config: inject(),
   apollo: queryManager(),
 
   async model() {
-    const { leadershipSectionAlias } = this.config;
+    const { leadershipSectionAlias, leadershipPrimarySiteOnly } = this.config;
+    if (leadershipPrimarySiteOnly) {
+      const siteId = get(this.modelFor('portal'), 'primarySite.id');
+      const variables = {
+        site: {
+          id: siteId,
+        },
+        leaders: {
+          siteId,
+          includeAliases: [leadershipSectionAlias],
+          pagination: { limit: 0 },
+          sort: { field: 'name', order: 'asc' },
+        },
+        children: {
+          pagination: { limit: 0 },
+          sort: { field: 'name', order: 'asc' },
+        }
+      };
+      const { websiteSite, websiteSections } = await this.apollo.query({
+        query: single,
+        variables,
+        fetchPolicy: 'network-only',
+      });
+
+      return { ...websiteSite, sections: websiteSections };
+    }
     const variables = {
       sites: {
         pagination: { limit: 0 },
@@ -24,7 +51,7 @@ export default Route.extend({
         sort: { field: 'name', order: 'asc' },
       },
     };
-    return this.apollo.query({ query, variables, fetchPolicy: 'network-only' }, 'websiteSites');
+    return this.apollo.query({ query: multi, variables, fetchPolicy: 'network-only' }, 'websiteSites');
   },
 
   afterModel() {

--- a/services/app/app/templates/portal/leadership.hbs
+++ b/services/app/app/templates/portal/leadership.hbs
@@ -7,11 +7,15 @@
 </div>
 
 <div class="row">
-  {{#each (get-edge-nodes this "model") as |site|}}
-    {{#if site.sections.edges.length}}
-      {{leadership/site site=site onUpdate=(action "update")}}
-    {{/if}}
-  {{/each}}
+  {{#if config.leadershipPrimarySiteOnly}}
+    {{leadership/site site=model onUpdate=(action "update")}}
+  {{else}}
+    {{#each (get-edge-nodes this "model") as |site|}}
+      {{#if site.sections.edges.length}}
+        {{leadership/site site=site onUpdate=(action "update")}}
+      {{/if}}
+    {{/each}}
+  {{/if}}
 </div>
 
 <div class="fixed-bottom fixed-right card">

--- a/services/graphql/src/definitions/config.js
+++ b/services/graphql/src/definitions/config.js
@@ -13,6 +13,7 @@ module.exports = gql`
     companyCustomAttributes: [CompanyCustomAttribute!]!
     leadershipEnabled: Boolean!
     leadershipPromotionsEnabled: Boolean!
+    leadershipPrimarySiteOnly: Boolean!
     leadershipCompanyLabel: String
     leadershipSectionAlias: String!
     leadershipSectionMax: Int!

--- a/services/graphql/src/env.js
+++ b/services/graphql/src/env.js
@@ -40,6 +40,7 @@ module.exports = cleanEnv(process.env, {
   LEADERSHIP_COMPANY_LABEL: str({ desc: 'If set check that a company has this label to enable the Leaders section.', default: '' }),
   LEADERSHIP_SECTION_ALIAS: nonemptystr({ desc: 'The leadership section alias to be displayed', default: 'leaders' }),
   LEADERSHIP_SECTION_MAX: num({ desc: 'The maximum number of leadership sections that can be selected per site.', default: 3 }),
+  LEADERSHIP_PRIMARY_SITE_ONLY: bool({ desc: 'If leadership sections should be limited to content primary site.', default: false }),
   CONTACT_URL: str({ desc: 'If configured, the URL that will be added to the navigation for support requests.', default: '' }),
   CONTACT_TEXT: str({ desc: 'Link text for navigation element', default: 'Contact Us' }),
   APP_LOCALE: str({ desc: 'The application locale', choices: ['en-us', 'es-mx'], default: 'en-us' }),

--- a/services/graphql/src/resolvers/config.js
+++ b/services/graphql/src/resolvers/config.js
@@ -7,6 +7,7 @@ const {
   LEADERSHIP_COMPANY_LABEL,
   LEADERSHIP_SECTION_ALIAS,
   LEADERSHIP_SECTION_MAX,
+  LEADERSHIP_PRIMARY_SITE_ONLY,
   COMPANY_CUSTOM_ATTRIBUTES,
   APP_LOCALE,
 } = require('../env');
@@ -31,6 +32,7 @@ module.exports = {
       leadershipCompanyLabel: LEADERSHIP_COMPANY_LABEL || null,
       leadershipSectionAlias: LEADERSHIP_SECTION_ALIAS,
       leadershipSectionMax: LEADERSHIP_SECTION_MAX,
+      leadershipPrimarySiteOnly: LEADERSHIP_PRIMARY_SITE_ONLY,
       locale: APP_LOCALE || 'en-us',
     }),
   },


### PR DESCRIPTION
Adds a new configuration flag to limit the returned leadership sections to the companys primary site

With primary site only flag disabled (default behavior)
![image](https://user-images.githubusercontent.com/1778222/145436958-914e24b2-d54d-43fd-92d5-3a67a45d43ca.png)

With primary site only flag enabled
![image](https://user-images.githubusercontent.com/1778222/145437024-9f23a34e-1fe1-44b7-bfac-b97c8c352607.png)
