### PR TITLE
Add support for quinary sections and change layout

### DIFF
--- a/services/app/app/components/leadership/category.js
+++ b/services/app/app/components/leadership/category.js
@@ -1,12 +1,19 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { get, computed } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['card-body row'],
+  tagName: 'fieldset',
+  classNames: ['leadership-category', 'border', 'mb-2', 'p-2'],
   category: null,
 
   sections: computed('category.children.edges.[]', function() {
     const sections = this.get('category.children.edges') || [];
     return sections.map(({ node }) => node);
+  }),
+
+  isMaxDepth: computed('sections', function() {
+    const sections = this.get('sections');
+    const hasGrandchildren = sections.some((section) => get(section, 'children.totalCount') > 0);
+    return !hasGrandchildren;
   }),
 });

--- a/services/app/app/gql/queries/portal/categories.js
+++ b/services/app/app/gql/queries/portal/categories.js
@@ -12,19 +12,51 @@ query ContentUpdateLeadershipData(
       node {
         id
         name
+        # Root sections
         sections(input: $leaders) {
+          totalCount
           edges {
             node {
               ...LeadershipSectionFragment,
+              # Primary
               children(input: $children) {
+                totalCount
                 edges {
                   node {
                     ...LeadershipSectionFragment,
+                    # Secondary
                     children(input: $children) {
                       totalCount
                       edges {
                         node {
                           ...LeadershipSectionFragment,
+                          # Tertiary
+                          children(input: $children) {
+                            totalCount
+                            edges {
+                              node {
+                                ...LeadershipSectionFragment,
+                                # Quaternary
+                                children(input: $children) {
+                                  totalCount
+                                  edges {
+                                    node {
+                                      ...LeadershipSectionFragment,
+                                      # Quinary???
+                                      children(input: $children) {
+                                        totalCount
+                                        edges {
+                                          node {
+                                            ...LeadershipSectionFragment,
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
                         }
                       }
                     }

--- a/services/app/app/gql/queries/portal/leadership-single.js
+++ b/services/app/app/gql/queries/portal/leadership-single.js
@@ -34,9 +34,16 @@ query ContentUpdateLeadershipData(
                       edges {
                         node {
                           # Quaternary
-                          id
-                          name
-                          alias
+                          ...LeadershipSectionFragment
+                            children(input: $children) {
+                              totalCount
+                              edges {
+                                node {
+                                # Quaternary
+                                ...LeadershipSectionFragment
+                                }
+                              }
+                            }
                         }
                       }
                     }

--- a/services/app/app/styles/app.scss
+++ b/services/app/app/styles/app.scss
@@ -169,3 +169,15 @@ body {
 .uploaded-image {
   min-height: 180px
 }
+
+.row.leadership-row:first-of-type {
+  margin-top: 0 !important;
+}
+
+fieldset.leadership-category {
+  min-width: 100%;
+}
+
+legend.leadership-category {
+  width: auto;
+}

--- a/services/app/app/templates/components/leadership/category.hbs
+++ b/services/app/app/templates/components/leadership/category.hbs
@@ -1,6 +1,35 @@
-<div class="col-12">
-  <h6 class="text-muted">{{ category.name }}</h6>
-</div>
-{{#each sections as |section|}}
-  {{leadership/section section=section selected=selected canSelect=canSelect onToggle=onToggle}}
-{{/each}}
+<legend class="leadership-category h6 text-muted">{{ category.name }}</legend>
+
+{{#if sections.length}}
+  {{#if isMaxDepth}}
+    <div class="row m-1">
+      {{#each sections as |section|}}
+        {{leadership/section
+          section=section
+          selected=selected
+          canSelect=canSelect
+          onToggle=onToggle
+        }}
+      {{/each}}
+    </div>
+  {{else}}
+    {{#each sections as |section|}}
+      {{leadership/category
+        category=section
+        selected=selected
+        canSelect=canSelect
+        onToggle=onToggle
+        depth=nextDepth
+      }}
+    {{/each}}
+  {{/if}}
+{{else}}
+  <div class="row m-1">
+    {{leadership/section
+      section=category
+      selected=selected
+      canSelect=canSelect
+      onToggle=onToggle
+    }}
+  </div>
+{{/if}}

--- a/services/app/app/templates/components/leadership/site.hbs
+++ b/services/app/app/templates/components/leadership/site.hbs
@@ -5,25 +5,29 @@
       Selected: <span class="badge">{{ selected }} / {{ maximum }}</span>
     </small>
   </h6>
-  {{#if hasChildren}}
-    {{#each sections as |section|}}
-      {{leadership/category
-        category=section
-        selected=_selected
-        canSelect=canSelect
-        onToggle=(action "toggle")
-      }}
-    {{/each}}
-  {{else}}
-    <div class="card-body row">
+  <div class="card-body">
+    {{#if hasChildren}}
       {{#each sections as |section|}}
-        {{leadership/section
-          section=section
-          selected=_selected
-          canSelect=canSelect
-          onToggle=(action "toggle")
-        }}
+        <div class="leadership-row row mt-3">
+          {{leadership/category
+            category=section
+            selected=_selected
+            canSelect=canSelect
+            onToggle=(action "toggle")
+          }}
+        </div>
       {{/each}}
-    </div>
-  {{/if}}
+    {{else}}
+      <div class="row">
+        {{#each sections as |section|}}
+          {{leadership/section
+            section=section
+            selected=_selected
+            canSelect=canSelect
+            onToggle=(action "toggle")
+          }}
+        {{/each}}
+      </div>
+    {{/if}}
+  </div>
 </div>


### PR DESCRIPTION
Update layout to better account for massive amounts of sections, and increase queried descendant depth to 4 (quinary from the root `leadershipSectionAlias`).

new
![image](https://user-images.githubusercontent.com/1778222/145463121-b3c19762-a838-4c30-b54c-946245520ec9.png)

old/current
![image](https://user-images.githubusercontent.com/1778222/145463995-e7217d38-4252-463b-9f09-bfc1b9c72687.png)
