### PR TITLE
Use non-button label for checkboxes, Directory page

### DIFF
--- a/services/app/app/templates/components/directory/category-tree.hbs
+++ b/services/app/app/templates/components/directory/category-tree.hbs
@@ -1,17 +1,20 @@
 <div class={{ rootClass }}>
-  <label role="button" class="d-flex align-items-center" {{action "collapse"}}>
-    {{#if node.children.length}}
+  {{#if node.children.length}}
+    <label role="button" class="d-flex align-items-center" {{action "collapse"}}>
       {{entypo-icon (if collapsed "chevron-right" "chevron-down") class="mr-2"}}
-    {{else}}
+      {{ node.name }}
+    </label>
+  {{else}}
+    <label class="d-flex align-items-center">
       <Input
         @type="checkbox"
         class="mr-2"
         @checked={{this.checked}}
         @change={{action "update"}}
       />
-    {{/if}}
-    {{ node.name }}
-  </label>
+      {{ node.name }}
+    </label>
+  {{/if}}
   {{#unless collapsed }}
     {{#if node.children.length}}
       <div class="ml-3">


### PR DESCRIPTION
This was preventing the checking of checkboxes on uncollapsed elements

![Screenshot from 2022-12-07 14-19-58](https://user-images.githubusercontent.com/46794001/206287151-ade6118d-e390-47ad-a751-be8bdd98501a.png)
![Screenshot from 2022-12-07 14-20-01](https://user-images.githubusercontent.com/46794001/206287155-e5683159-67ac-48c5-a492-a4b1bfaea42f.png)
