### PR TITLE
Verify incoming "truthy" value for verbiage(s)

### DIFF
--- a/services/app/app/controllers/portal/company.js
+++ b/services/app/app/controllers/portal/company.js
@@ -8,7 +8,10 @@ export default Controller.extend({
 
   logo: computed.reads('model.primaryImage.src'),
   companyDetailsVerbiage: computed('config.companyDetailsVerbiage', function() {
-    return htmlSafe(this.config.companyDetailsVerbiage)
+    if (this.config.companyDetailsVerbiage) {
+      return htmlSafe(this.config.companyDetailsVerbiage)
+    }
+    return null;
   }),
 
   actions: {

--- a/services/app/app/controllers/portal/index.js
+++ b/services/app/app/controllers/portal/index.js
@@ -23,6 +23,9 @@ export default Controller.extend({
   }),
   categoryPrefix: computed.reads('config.leadershipCategoryPrefix'),
   portalPageVerbiage: computed('config.portalPageVerbiage', function() {
-    return htmlSafe(this.config.portalPageVerbiage);
+    if (this.config.portalPageVerbiage) {
+      return htmlSafe(this.config.portalPageVerbiage);
+    }
+    return null;
   }),
 });

--- a/services/app/app/controllers/portal/promotions.js
+++ b/services/app/app/controllers/portal/promotions.js
@@ -13,7 +13,10 @@ export default Controller.extend({
     });
   }),
   promotionsVerbiage: computed('config.promotionsVerbiage', function() {
-    return htmlSafe(this.config.promotionsVerbiage);
+    if (this.config.promotionsVerbiage) {
+      return htmlSafe(this.config.promotionsVerbiage);
+    }
+    return null;
   }),
 
   isAddDisabled: computed.gte('promotions.length', 4),


### PR DESCRIPTION
Likely given the Ember version this uses: https://github.com/emberjs/ember.js/issues/17486 still impacts this project and thus the presumed logic of the empty string returning a falsy value from `htmlSafe` was incorrect.

![Screenshot from 2023-02-07 13-07-52](https://user-images.githubusercontent.com/46794001/217341726-23645d48-3979-4f48-9fbf-c6d11d8c717b.png)
![Screenshot from 2023-02-07 13-07-54](https://user-images.githubusercontent.com/46794001/217341731-a81248cc-9aa6-4294-8bea-ef07afa25906.png)
![Screenshot from 2023-02-07 13-07-57](https://user-images.githubusercontent.com/46794001/217341741-1b5513e8-e333-4011-b770-15f6caa6b912.png)
