### PR TITLE
Set sections ID to `sectionIds` regardless of start date.

### DIFF
--- a/services/app/app/controllers/review/leadership.js
+++ b/services/app/app/controllers/review/leadership.js
@@ -34,9 +34,8 @@ export default Controller.extend(ActionMixin, {
   }),
 
   sectionIds: computed('model.company.{published,websiteSchedules.[]}', function() {
-    const published = this.get('model.company.published');
     const schedules = this.get('model.company.websiteSchedules') || [];
-    return schedules.filter(({ start }) => start === published).map(({ section: { id } }) => id);
+    return Array.from(new Set(schedules.map(({ section: { id } }) => id)));
   }),
 
   sites: computed('model.sections.[]', function() {


### PR DESCRIPTION
```{
  "data": {
    "contentHash": {
      "id": 21171745,
      "name": "Validated Claim Support",
      "hash": "b107518208ad6ffa04f94f5ed0bd2535",
      "published": 1566066009794,
      "websiteSchedules": [
        {
          "start": 1566066009000,
          "section": {
            "id": 77320,
            "name": "Business",
            "__typename": "WebsiteSection"
          },
          "__typename": "ContentWebsiteSchedule"
        },
        {
          "start": 1566066009000,
          "section": {
            "id": 77327,
            "name": "Testing",
            "__typename": "WebsiteSection"
          },
          "__typename": "ContentWebsiteSchedule"
        },
        {
          "start": 1566066009000,
          "section": {
            "id": 84049,
            "name": "Bath & Body",
            "__typename": "WebsiteSection"
          },
          "__typename": "ContentWebsiteSchedule"
        },
        {
          "start": 1566066009000,
          "section": {
            "id": 84059,
            "name": "Private Label",
            "__typename": "WebsiteSection"
          },
          "__typename": "ContentWebsiteSchedule"
        }
      ],
    }
  }
}
```

Ref: https://update.allured.com/review/6414e467fd4da63d7f3d1bdf/leadership

Due to `published !== schedule.start` for all of these **none** of this items schedules count towards `sectionIds` causing the validation to fail for these sections already being scheduled to and further causing a duplicate key error to throw when attempting to publish changes.