### PR TITLE
Address workflow issues with Promotions Submission page.

### DIFF
--- a/services/app/app/controllers/portal/promotions.js
+++ b/services/app/app/controllers/portal/promotions.js
@@ -6,12 +6,6 @@ export default Controller.extend({
   isModalOpen: false,
   count: 0,
 
-  promotions: computed('model.[]', function() {
-    return this.get('model.promotions.edges').map(({ node }) => {
-      const { id, name, linkUrl, linkText, primaryImage } = node;
-      return { id, name, linkUrl, linkText, ...(primaryImage && { primaryImage } || { primaryImage: { src: null } }) };
-    });
-  }),
   promotionsVerbiage: computed('config.promotionsVerbiage', function() {
     if (this.config.promotionsVerbiage) {
       return htmlSafe(this.config.promotionsVerbiage);

--- a/services/app/app/routes/portal/promotions.js
+++ b/services/app/app/routes/portal/promotions.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { queryManager } from 'ember-apollo-client';
+import { get } from '@ember/object';
 import query from '@base-cms/company-update-app/gql/queries/portal/promotions';
 
 export default Route.extend({
@@ -13,8 +14,18 @@ export default Route.extend({
     return model;
   },
 
-  afterModel() {
+  afterModel(model) {
     const { hash } = this.paramsFor('portal');
+    const returnedPromotions = get(model, 'promotions.edges');
+    const promotions = Array.isArray(returnedPromotions) ?  returnedPromotions : [];
+    const mappedPromotions = promotions.map(({ node }) => {
+      const { id, name, linkUrl, linkText, primaryImage } = node;
+      return { id, name, linkUrl, linkText, ...(primaryImage && { primaryImage } || { primaryImage: { src: null } }) };
+    });
     this.controllerFor('portal.promotions').set('hash', hash);
+    this.controllerFor('portal.promotions').set('promotions', mappedPromotions)
+    this.controllerFor('portal.promotions').set('payload.add', []);
+    this.controllerFor('portal.promotions').set('payload.remove', []);
+    this.controllerFor('portal.promotions').set('payload.update', []);
   },
 });


### PR DESCRIPTION
This corrects the workflow issues faced with trying to utilize the Promotions portion of the form. At present if a promotions update is submitted and a user returns back to the promotions page ("oh I forgot one") and submits again, the page loads with the previously submitted items still allowed to be submitted again due to the model still being considered "dirty", this will correct this to refresh the `add`, `remove` and `update` arrays to be empty upon subsequent visits to the page, in additional to reloading the promotions list from Base itself.