### PR TITLE
Address workflow issues with Promotions Review page

### DIFF
--- a/services/app/app/controllers/review/promotion.js
+++ b/services/app/app/controllers/review/promotion.js
@@ -108,7 +108,7 @@ export default Controller.extend(ActionMixin, {
       set(this, 'isPublishing', true);
       try {
         const { id } = this.get('model.submission');
-        const promotions = this.get('model.promotions');
+        const promotions = this.get('promotions');
         const contentId = this.get('model.company.id');
         const contentName = this.get('model.company.name');
         const primarySiteId = this.get('model.company.primarySite.id');

--- a/services/app/app/templates/review/promotion.hbs
+++ b/services/app/app/templates/review/promotion.hbs
@@ -10,7 +10,7 @@
 </div>
 
 <div class="row">
-  {{#each model.promotions as |object|}}
+  {{#each promotions as |object|}}
     {{#if (and object.original object.updated)}}
       {{!-- Modified --}}
       {{promotion-card-review


### PR DESCRIPTION
This corrects the workflow issues faced with trying to utilize the Promotions Review portion of the form. At present because the model remains in it's previously loaded state promotions are not subsequently refreshed between each review resulting in blank pages that are only populated upon a refresh of the page. This should correct this in re-computing the promotions array on each page view which should prevent the page being blank upon initial loading of it.