### PR TITLE
Multiple directory alias support

### DIFF
--- a/services/app/app/routes/portal/directory-sections.js
+++ b/services/app/app/routes/portal/directory-sections.js
@@ -26,7 +26,7 @@ export default Route.extend({
     if (directorySectionsPrimarySiteOnly) {
       const variables = {
         site: { id: siteId },
-        leaders: { includeAliases: [directorySectionsAlias], ...pagination, siteId },
+        leaders: { includeAliases: [...directorySectionsAlias.split('|')], ...pagination, siteId },
         children: pagination,
         content: { hash, status: 'any' },
       };
@@ -46,7 +46,7 @@ export default Route.extend({
 
     const variables = {
       sites: pagination,
-      leaders: { includeAliases: [directorySectionsAlias], ...pagination },
+      leaders: { includeAliases: [...directorySectionsAlias.split('|')], ...pagination },
       children: pagination,
       content: { hash, status: 'any' },
     };

--- a/services/graphql/src/env.js
+++ b/services/graphql/src/env.js
@@ -41,7 +41,7 @@ module.exports = cleanEnv(process.env, {
   DIRECTORY_CATEGORY_IDS: str({ desc: 'CSV list of category taxonomy ids to display', default: '' }),
   DIRECTORY_SELECTION_MAX: num({ desc: 'The maximum number of children that can be selected per category. Set 0 to disable', default: 0 }),
   DIRECTORY_SECTIONS_ENABLED: bool({ desc: 'If the online directory section should be displayed', default: false }),
-  DIRECTORY_SECTIONS_ALIAS: nonemptystr({ desc: 'The online directory section alias to be displayed', default: 'directory' }),
+  DIRECTORY_SECTIONS_ALIAS: nonemptystr({ desc: 'The online directory section alias to be displayed, can include multiple by separating each with |', default: 'directory' }),
   DIRECTORY_SECTIONS_PRIMARY_SITE_ONLY: bool({ desc: 'If online directory sections should be limited to content primary site.', default: false }),
   DIRECTORY_SECTIONS_SCHEDULED_SITE_ONLY: bool({ desc: 'If online directory sections should be limited sites that have schedules.', default: false }),
   LOGO_URL: str({ desc: 'If configured, will be replace the branding in the navigation.', default: '' }),


### PR DESCRIPTION
Submission side (showing Industry Leaders for Petfood Industry and Directory for Feed & Grain):
![Screenshot from 2024-10-04 08-08-30](https://github.com/user-attachments/assets/23f14cca-d7fe-49d7-9ecb-8deac5b8c7b0)
![Screenshot from 2024-10-04 08-08-41](https://github.com/user-attachments/assets/eef1e5a6-bad6-4b5a-9cf2-03bd10bc53ea)

Review side (showing categories selected from both of the above, this part of the form already supported this):
![Screenshot from 2024-10-04 08-09-47](https://github.com/user-attachments/assets/94df3ff3-efd1-4e12-9594-b198fe902d9f)
