### PR TITLE
Add set to null if invalid prop is set for youtube prop

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
         node-version: 10.x
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: yarn-cache
       with:
         path: '**/node_modules'

--- a/services/app/app/components/company-card/youtube.js
+++ b/services/app/app/components/company-card/youtube.js
@@ -14,6 +14,9 @@ export default Component.extend({
     if (!playlistId) return true;
     const variables = { input: { playlistId } };
     const result = await this.apollo.query({ query: queryPlaylistId, variables });
+    if (!result.validateYoutubePlaylistId) {
+      this.set('model.youtube.playlistId', null);
+    }
     return result.validateYoutubePlaylistId;
   },
 
@@ -21,13 +24,20 @@ export default Component.extend({
     if (!channelId) return true;
     const variables = { input: { channelId } };
     const result = await this.apollo.query({ query: queryChannelId, variables });
+    if (!result.validateYoutubeChannelId) {
+      this.set('model.youtube.channelId', null);
+    }
     return result.validateYoutubeChannelId;
   },
 
   async validateUsername(username) {
     if (!username) return true;
+    
     const variables = { input: { username }};
     const result = await this.apollo.query({ query: queryUsername, variables });
+    if (!result.validateYoutubeUsername) {
+      this.set('model.youtube.username', null);
+    }
     return result.validateYoutubeUsername;
   },
 


### PR DESCRIPTION
https://trello.com/c/5GTLlGVr/ && 
If a user puts in an invalid youtube prop it resets it to null and doesnt allow for them to submit invalid props.  This should fix the `glitch`, but not that if the company currenty has props and the enter new invalid ones it will attempt to set it to null and the editor will have to discard the changes.

Valid Input:
<img width="759" alt="Screenshot 2025-03-07 at 10 18 52 AM" src="https://github.com/user-attachments/assets/dcda7cd9-acb8-4326-92fa-7de397ff6296" />

If you ad an any character to the end of any of those input it will set them to null, unsetting them and warning the user it was invalid.  If they hit submit it will put a request to the editor to remove or set that input to null. 

Add and invalid character to the end of Username:
<img width="770" alt="Screenshot 2025-03-07 at 10 21 32 AM" src="https://github.com/user-attachments/assets/1df2da51-ef33-407a-b8dc-848af355119c" />

Submit it:
<img width="941" alt="Screenshot 2025-03-07 at 10 21 47 AM" src="https://github.com/user-attachments/assets/04aac955-9cf2-4494-b427-a30a57f1f23d" />

What the editor will get as a requested update:
<img width="473" alt="Screenshot 2025-03-07 at 10 21 58 AM" src="https://github.com/user-attachments/assets/50f64eff-df17-4127-b0c2-4358ecab5f95" />


