### PR TITLE
Allow editor to publish only removal of sections

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v4
       with:
         node-version: 10.x
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       id: yarn-cache
       with:
         path: '**/node_modules'

--- a/services/app/app/controllers/review/directory-sections.js
+++ b/services/app/app/controllers/review/directory-sections.js
@@ -18,7 +18,6 @@ export default Controller.extend(ActionMixin, {
   isDiscarding: false,
 
   isPublishDisabled: computed('isDisabled', 'isConflicting', 'selected.length', 'removed.length', function() {
-    console.log('first: ', this.get('removed'), this.get('isConflicting'), this.get('selected'));
     if (this.get('isConflicting')) return true;
     if (!this.get('selected.length') && !this.get('removed.length')) return true;
     return this.get('isDisabled');

--- a/services/app/app/controllers/review/directory-sections.js
+++ b/services/app/app/controllers/review/directory-sections.js
@@ -17,9 +17,10 @@ export default Controller.extend(ActionMixin, {
   isPublishing: false,
   isDiscarding: false,
 
-  isPublishDisabled: computed('isDisabled', 'isConflicting', 'selected.length', function() {
+  isPublishDisabled: computed('isDisabled', 'isConflicting', 'selected.length', 'removed.length', function() {
+    console.log('first: ', this.get('removed'), this.get('isConflicting'), this.get('selected'));
     if (this.get('isConflicting')) return true;
-    if (!this.get('selected.length')) return true;
+    if (!this.get('selected.length') && !this.get('removed.length')) return true;
     return this.get('isDisabled');
   }),
 


### PR DESCRIPTION
This does not touch the restriction put in place on the submission form restricting the end user from removing themselves from leaders section Please see the examples below. 

**Leaders**(/portal/4dfb8dbec8096e42730989bd47cba779/leadership ~ You can not remove the client section):
<img width="2041" alt="Screenshot 2025-03-10 at 10 19 12 AM" src="https://github.com/user-attachments/assets/0bb38027-613f-412e-8e2a-3e7078c0d9e1" />

**Directory**(/portal/4dfb8dbec8096e42730989bd47cba779/directory-sections ~ you can remove what you want):
<img width="2151" alt="Screenshot 2025-03-10 at 10 18 45 AM" src="https://github.com/user-attachments/assets/766c995e-69d2-4f39-b31c-e0c4323fcee3" />
<img width="2049" alt="Screenshot 2025-03-10 at 10 18 56 AM" src="https://github.com/user-attachments/assets/622190f8-7ac1-4e43-b383-2258c1c749a0" />

**This change allows the editor to approve the removal of just sections.... not that they will have to be aware if they remove leaders section it will remove that reporting.** 
<img width="950" alt="Screenshot 2025-03-10 at 10 23 07 AM" src="https://github.com/user-attachments/assets/7379e53a-79d9-447d-92e7-9b12b49e66f9" />

